### PR TITLE
Handle individual parser error

### DIFF
--- a/src/Parsers/Papertrail/Papertrail_01.php
+++ b/src/Parsers/Papertrail/Papertrail_01.php
@@ -19,7 +19,7 @@ class Papertrail_01 extends Parser
             return false;
         }
 
-        $this->payload = json_decode( $this->request->input( 'payload' ), true );
+        $this->payload = json_decode( $this->request->post( 'payload' ), true );
 
         $needle = 'https://papertrailapp.com/searches/2';
         return array_key_exists('saved_search', $this->payload) &&

--- a/src/WebhookParser.php
+++ b/src/WebhookParser.php
@@ -9,16 +9,23 @@ class Main {
      * @param \Illuminate\Http\Request $request
      * @return null|\WebhookParser\WebhookIncident
      */
-    static function run(Request $request) {
+    static function run(Request $request, $errorCallback = null) {
         $parserProviders = new ParserProvider(true);
         foreach ($parserProviders->getClassList() as $providerClass) {
-            /** @var \WebhookParser\Parser $cls */
-            $cls = new $providerClass($request);
+            try {
+                /** @var \WebhookParser\Parser $cls */
+                $cls = new $providerClass( $request );
 
-            if ($cls->isMatch()) {
-                $incident = $cls->extract();
-                $incident->setParser($cls->companyName(), $cls->version());
-                return $incident;
+                if ($cls->isMatch()) {
+                    $incident = $cls->extract();
+                    $incident->setParser( $cls->companyName(), $cls->version() );
+
+                    return $incident;
+                }
+            } catch(\Exception $e) {
+                if (is_callable($errorCallback) ) {
+                    $errorCallback($e);
+                }
             }
         }
         return null;


### PR DESCRIPTION
Wrap the code creating and running a parser with a try/catch. This allow individual parser to fail dramatically while keep trying other ones. 

Also accept an error callback in order to log the error.